### PR TITLE
Update for Sketch 3

### DIFF
--- a/Preview.jstalk
+++ b/Preview.jstalk
@@ -21,46 +21,46 @@
 // THE SOFTWARE.
 
 var PREVIEW_APPLICATION = "Skala Preview";
-var PREVIEW_SLICE_NAME = "Preview";
+var PREVIEW_EXPORTABLE_LAYER_NAME = "Preview";
 
 var PREVIEW_DIRECTORY_NAME = "com.marcisme.sketch-preview";
 var PREVIEW_FILE_NAME = "preview.png";
 
 function preview() {
-  var artboardOrSlice = findPreview();
-  if (artboardOrSlice) {
-    writeAndOpenPreviewFile(artboardOrSlice);
+  var artboardOrExportableLayer = findPreview();
+  if (artboardOrExportableLayer) {
+    writeAndOpenPreviewFile(artboardOrExportableLayer);
   }
   else {
-    [doc showMessage:"The Preview plugin requires a selected Artboard or a slice named '" + PREVIEW_SLICE_NAME + "'"];
+    [doc showMessage:"The Preview plugin requires a selected Artboard or a exportable layer named '" + PREVIEW_EXPORTABLE_LAYER_NAME + "'"];
   }
 }
 
 function findPreview() {
-  return findPreviewSlice() || findPreviewArtboard();
+  return findPreviewExportableLayer() || findPreviewArtboard();
 }
 
 function findPreviewArtboard() {
   return [[doc currentPage] currentArtboard];
 }
 
-function findPreviewSlice() {
-  var slices = [[doc currentPage] allSlices];
-  for (var i = 0; i < [slices count]; i++) {
-    var slice = slices[i];
-    if (isPreviewSlice(slice)) {
-      return slice;
+function findPreviewExportableLayer() {
+  var layers = [[doc currentPage] exportableLayers];
+  for (var i = 0; i < [layers count]; i++) {
+    var layer = layers[i];
+    if (isPreviewExportableLayer(layer)) {
+      return layer;
     }
   }
 }
 
-function isPreviewSlice(slice) {
-  return [[slice name] localizedCaseInsensitiveCompare:PREVIEW_SLICE_NAME] == NSOrderedSame;
+function isPreviewExportableLayer(layer) {
+  return [[layer name] localizedCaseInsensitiveCompare:PREVIEW_EXPORTABLE_LAYER_NAME] == NSOrderedSame;
 }
 
-function writeAndOpenPreviewFile(artboardOrSlice) {
+function writeAndOpenPreviewFile(artboardOrExportableLayer) {
   var previewFilePath = getPreviewFilePath();
-  [doc saveArtboardOrSlice:artboardOrSlice toFile:previewFilePath];
+  [doc saveArtboardOrSlice:artboardOrExportableLayer toFile:previewFilePath];
   openPreviewFile(previewFilePath);
 }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or `~/Library/Application\ Support/sketch/plugins` as described in the Sketch
 
 # Compatibility
 
-This plugin was most recently tested with the Sketch Version 2.4.3 (5347), Skala Preview 1.6.0 (and Skala View for Andriod 1.2.2)
+This plugin was most recently tested with the Sketch Version 3.0 (7574), Skala Preview 1.6.0 (and Skala View for Andriod 1.2.2)
 
 # Author
 
@@ -47,6 +47,7 @@ Big thanks to these people for their contributions.
 
 * [Jacob Elias](https://github.com/jelias) ([@\_jelias\_](https://twitter.com/_jelias_))
 * [David Klawitter](https://github.com/davidklaw)
+* [Tomas Linhart](https://github.com/TomasLinhart)
 
 # License
 


### PR DESCRIPTION
Bohemian Coding removed allSlices and slices methods in Sketch 3 so the plugin was not working anymore. Unfortunately this change is not documented in their documentation.

Using class-dump I have discovered something called exportableLayers that includes slices and all layers that were made exportable.

I used this property and changed code occurences of slices to exportable layers. Because name slice is not relevant anymore.

I also added myself to contributors. I hope you don't mind.
