### PR TITLE
Added iPhone 6 and iPhone 6 Plus Scale Sizes

### DIFF
--- a/Preview (iPhone 6 Plus).sketchplugin
+++ b/Preview (iPhone 6 Plus).sketchplugin
@@ -1,0 +1,147 @@
+// Preview file in Skala Preview (ctrl alt p)
+
+// Copyright (c) 2013 Marc Schwieterman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// configuration
+
+var DEBUG = false;
+
+var PREVIEW_APPLICATION = "Skala Preview";
+var PREVIEW_TARGET_NAME = "Preview";
+
+var PREVIEW_DIRECTORY_NAME = "com.marcisme.sketch-preview";
+var LOG_PREFIX = "sketch-preview";
+var PREVIEW_FILE_NAME = "preview.png";
+
+// logging functions
+
+function debug(message) {
+  if (DEBUG) {
+    logWithPrefix(message);
+  }
+}
+
+function error(message) {
+  logWithPrefix(message);
+}
+
+function logWithPrefix(message) {
+  log(LOG_PREFIX + ": " + message);
+}
+
+// preview functions
+
+function preview() {
+  var previewTarget = findPreviewTarget();
+  if (previewTarget) {
+    writeAndOpenPreviewFile(previewTarget);
+  }
+  else {
+    [doc showMessage:"The Preview plugin requires a selected Artboard or a slice named '" + PREVIEW_TARGET_NAME + "'"];
+  }
+}
+
+function findPreviewTarget() {
+  return findNamedPreviewTarget() || findSelectedPreviewTarget();
+}
+
+function findSelectedPreviewTarget() {
+  debug("Searching for selected Artboard");
+  var currentArtboard = [[doc currentPage] currentArtboard];
+  if (currentArtboard) {
+    debug("Found selected Artboard: " + [currentArtboard name]);
+  }
+  else {
+    debug("No Artboard selected");
+  }
+
+  return currentArtboard;
+}
+
+function findNamedPreviewTarget() {
+  debug("Searching for named preview slice: " + PREVIEW_TARGET_NAME);
+  var targets = allTargets();
+  for (var i = 0; i < [targets count]; i++) {
+    var target = targets[i];
+    if (isPreviewTarget([target name])) {
+      debug("Found named preview slice");
+      return target;
+    }
+  }
+  debug("No named preview slice found");
+}
+
+function allTargets() {
+  var currentPage = [doc currentPage];
+  if ([currentPage respondsToSelector:"allSlices"]) {
+    // Sketch 2
+    return [currentPage allSlices];
+  }
+  else if ([currentPage respondsToSelector:"exportableLayers"]) {
+    // Sketch 3
+    return [currentPage exportableLayers];
+  } else {
+    error("Unable to search for target slice; Sketch implementation may have changed");
+    // Return empty array, so we move on to the next strategy
+    return [NSArray new];
+  }
+}
+
+function isPreviewTarget(name) {
+  return [name localizedCaseInsensitiveCompare:PREVIEW_TARGET_NAME] == NSOrderedSame;
+}
+
+function writeAndOpenPreviewFile(previewTarget) {
+  var previewFilePath = getPreviewFilePath();
+  var ratio = 1;
+  var frame = [previewTarget frame];
+
+
+  if ([frame height] > [frame width]){
+    ratio = 2208 / [frame height];
+  } else {
+    ratio = 2208 / [frame width];
+  } //checks for Landscape vs Portrait Screens
+
+  [previewTarget multiplyBy:ratio];
+  [doc saveArtboardOrSlice:previewTarget toFile:previewFilePath];
+  [previewTarget multiplyBy: 1 / ratio];
+  
+  openPreviewFile(previewFilePath);
+}
+
+function getPreviewFilePath() {
+  return getPreviewDirectory() + "/" + PREVIEW_FILE_NAME;
+}
+
+function getPreviewDirectory() {
+  var fileManager = [NSFileManager defaultManager];
+  var cachesURL = [[fileManager URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask] lastObject];
+  return [[cachesURL URLByAppendingPathComponent:PREVIEW_DIRECTORY_NAME] path];
+}
+
+function openPreviewFile(previewFilePath) {
+  if(![[NSWorkspace sharedWorkspace] openFile:previewFilePath withApplication:PREVIEW_APPLICATION]]) {
+    [doc showMessage:"Failed to open preview file; Make sure '" + PREVIEW_APPLICATION + "' is installed."];
+  }
+}
+
+preview();

--- a/Preview (iPhone 6).sketchplugin
+++ b/Preview (iPhone 6).sketchplugin
@@ -1,0 +1,152 @@
+// Preview file in Skala Preview (cmd ctrl p)
+
+// Copyright (c) 2013 Marc Schwieterman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// configuration
+
+var DEBUG = false;
+
+var PREVIEW_APPLICATION = "Skala Preview";
+var PREVIEW_TARGET_NAME = "Preview";
+
+var PREVIEW_DIRECTORY_NAME = "com.marcisme.sketch-preview";
+var LOG_PREFIX = "sketch-preview";
+var PREVIEW_FILE_NAME = "preview.png";
+
+// logging functions
+
+function debug(message) {
+  if (DEBUG) {
+    logWithPrefix(message);
+  }
+}
+
+function error(message) {
+  logWithPrefix(message);
+}
+
+function logWithPrefix(message) {
+  log(LOG_PREFIX + ": " + message);
+}
+
+// preview functions
+
+function preview() {
+  var previewTarget = findPreviewTarget();
+  if (previewTarget) {
+    writeAndOpenPreviewFile(previewTarget);
+  }
+  else {
+    [doc showMessage:"The Preview plugin requires a selected Artboard or a slice named '" + PREVIEW_TARGET_NAME + "'"];
+  }
+}
+
+function findPreviewTarget() {
+  return findNamedPreviewTarget() || findSelectedPreviewTarget();
+}
+
+function findSelectedPreviewTarget() {
+  debug("Searching for selected Artboard");
+  var currentArtboard = [[doc currentPage] currentArtboard];
+  if (currentArtboard) {
+    debug("Found selected Artboard: " + [currentArtboard name]);
+  }
+  else {
+    debug("No Artboard selected");
+  }
+
+  return currentArtboard;
+}
+
+function findNamedPreviewTarget() {
+  debug("Searching for named preview slice: " + PREVIEW_TARGET_NAME);
+  var targets = allTargets();
+  for (var i = 0; i < [targets count]; i++) {
+    var target = targets[i];
+    if (isPreviewTarget([target name])) {
+      debug("Found named preview slice");
+      return target;
+    }
+  }
+  debug("No named preview slice found");
+}
+
+function allTargets() {
+  var currentPage = [doc currentPage];
+  if ([currentPage respondsToSelector:"allSlices"]) {
+    // Sketch 2
+    return [currentPage allSlices];
+  }
+  else if ([currentPage respondsToSelector:"exportableLayers"]) {
+    // Sketch 3
+    return [currentPage exportableLayers];
+  } else {
+    error("Unable to search for target slice; Sketch implementation may have changed");
+    // Return empty array, so we move on to the next strategy
+    return [NSArray new];
+  }
+}
+
+function isPreviewTarget(name) {
+  return [name localizedCaseInsensitiveCompare:PREVIEW_TARGET_NAME] == NSOrderedSame;
+}
+
+function writeAndOpenPreviewFile(previewTarget) {
+  var previewFilePath = getPreviewFilePath();
+  var ratio = 1;
+
+  var frame = [previewTarget frame];
+
+  if ([frame height] > [frame width]){
+    ratio = 1334 / [frame height];
+  } else {
+    ratio = 1334 / [frame width];
+  } //checks for Landscape vs Portrait Screens
+
+  [previewTarget multiplyBy:ratio];
+
+  [doc saveArtboardOrSlice:previewTarget toFile:previewFilePath];
+  [previewTarget multiplyBy: 1 / ratio];
+  openPreviewFile(previewFilePath);
+}
+
+function scaleImageToSize(previewFilePath) {
+
+
+}
+
+function getPreviewFilePath() {
+  return getPreviewDirectory() + "/" + PREVIEW_FILE_NAME;
+}
+
+function getPreviewDirectory() {
+  var fileManager = [NSFileManager defaultManager];
+  var cachesURL = [[fileManager URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask] lastObject];
+  return [[cachesURL URLByAppendingPathComponent:PREVIEW_DIRECTORY_NAME] path];
+}
+
+function openPreviewFile(previewFilePath) {
+  if(![[NSWorkspace sharedWorkspace] openFile:previewFilePath withApplication:PREVIEW_APPLICATION]]) {
+    [doc showMessage:"Failed to open preview file; Make sure '" + PREVIEW_APPLICATION + "' is installed."];
+  }
+}
+
+preview();


### PR DESCRIPTION
Using the iPhone 6 plugin will automatically scale the output image into the iPhone 6 resolutions without scaling the original ArtBoard. Useful for those designing in points (1x) rather than in pixels (Retina 2x / 3x) resolutions. (Plugin also detects Portrait and Landscape and scales accordingly).

iPhone 6 Shortcut: ⌘ + Ctrl + P 
iPhone 6+ Shortcut: Ctrl + Alt + P  
