### PR TITLE
Tested latest versions and updated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ you some idea of the latest versions that have worked for other people. Feel
 free to submit a [pull request](https://github.com/marcisme/sketch-preview/compare/)
 if you've used the plugin with a newer version of any of these applications.
 
-* Sketch 3.3.2 (12043)
-* Skala Preview 2.0 (205)
+* Sketch 3.4 (15575)
+* Skala Preview 2.0 (207)
 * Skala View for iOS 2.0
-* Skala View for Android 1.2.2
+* Skala View for Android 2.0
 
 # Troubleshooting
 


### PR DESCRIPTION
Just tested the Sketch Preview plugin with Sketch 3.4 (15575), Skala Preview 2.0 (207), and Skala View for Android 2.0. All behaved as expected. ～(￣▽￣～)
