### PR TITLE
Adding scaling support for 3.5x displays

### DIFF
--- a/SketchPreview.sketchplugin/Contents/Sketch/Preview Setup.sketchscript
+++ b/SketchPreview.sketchplugin/Contents/Sketch/Preview Setup.sketchscript
@@ -52,7 +52,7 @@ function requestPreviewSize(config, doc) {
   })
   [accessory addSubview:matrix]
 
-  var segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSMakeRect(20, 30, 250, 25)]
+  var segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSMakeRect(20, 30, 512, 25)]
   [segmentedControl setSegmentCount:config.PREVIEW_SIZE_LABELS.length]
   [segmentedControl setEnabled:false]
   config.PREVIEW_SIZE_LABELS.forEach(function(sizeLabel, i) {

--- a/SketchPreview.sketchplugin/Contents/Sketch/lib/common.js
+++ b/SketchPreview.sketchplugin/Contents/Sketch/lib/common.js
@@ -62,7 +62,7 @@ function Config() {
   var CONFIG_FILE_NAME = "config.plist"
   var configDictionary
 
-  var PREVIEW_SIZES = [0.5, 1.0, 1.5, 2.0, 3.0, 4.0]
+  var PREVIEW_SIZES = [0.5, 1.0, 1.5, 2.0, 3.0, 3.5, 4.0]
   this.PREVIEW_SIZE_LABELS = PREVIEW_SIZES.map(function(size) { return size + "x" })
   var PREVIEW_SIZE_INDEX_KEY = "previewSizeIndex"
 


### PR DESCRIPTION
Adding 3.5x to the list of supported scale factors (to account for
devices such as Nexus 6, per the device metrics list here:
https://design.google.com/devices/).